### PR TITLE
Zo verdwijnt deze foutmelding:

### DIFF
--- a/bin/inline_forms
+++ b/bin/inline_forms
@@ -61,6 +61,7 @@ source 'http://rubygems.org'
 "
 gemfile_gems = "
 
+gem 'test-unit'
 gem 'rails'
 gem 'rake'
 gem 'jquery-rails'


### PR DESCRIPTION
zie: http://stackoverflow.com/questions/7957330/ruby-1-9-3-breaks-rake-test

Zo forken op github werkt wel makelijk, nu alleen nog terugkoppelen naar rubygems.org.

Devise User model install with added name field...
      invoke  active_record
      create    db/migrate/20120508130544_devise_create_users.rb
      create    app/models/user.rb
      invoke    rspec
      create      spec/models/user_spec.rb
      insert    app/models/user.rb
       route  devise_for :users
/home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:167:in `block in non_options': file not found: User (ArgumentError)
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:146:in`map!'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:146:in `non_options'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:207:in`non_options'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:52:in `process_args'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/minitest/unit.rb:891:in`_run'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/minitest/unit.rb:884:in `run'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:21:in`run'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:326:in `block (2 levels) in autorun'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:27:in`run_once'
    from /home/carel/.rvm/rubies/ruby-1.9.3-rc1/lib/ruby/1.9.1/test/unit.rb:325:in `block in autorun'
