### PR TITLE
ckeditor fix csrf_token

### DIFF
--- a/lib/app/assets/javascripts/ckeditor/config.js
+++ b/lib/app/assets/javascripts/ckeditor/config.js
@@ -26,8 +26,8 @@ CKEDITOR.editorConfig = function( config )
     config.filebrowserImageBrowseUrl = "/ckeditor/pictures";
 
     // The location of a script that handles file uploads in the Image dialog.
-    var token = $('meta[name=csrf-token]').attr('content')
-    var param = $('meta[name=csrf-param]').attr('content')
+    var token = $('meta[name=csrf-token]').attr('content');
+    var param = $('meta[name=csrf-param]').attr('content');
     config.filebrowserImageUploadUrl = "/ckeditor/pictures" + "?" + token + "=" + param;
     // The location of a script that handles file uploads.
     config.filebrowserUploadUrl = "/ckeditor/attachment_files";


### PR DESCRIPTION
This is a fix to include csrf_token when uploading image via Image dialog
