### PR TITLE
Using rvm1-capistrano3 instead of capistrano-rvm

### DIFF
--- a/bin/inline_forms_installer_core.rb
+++ b/bin/inline_forms_installer_core.rb
@@ -47,7 +47,7 @@ gem_group :development do
   gem 'capistrano', '~> 3.6', require: false
   gem 'capistrano-rails', '~> 1.3', require: false
   gem 'capistrano-bundler', '~> 1.3', require: false
-  gem 'capistrano-rvm', require: false
+  gem 'rvm1-capistrano3', require: false
   gem "capistrano3-unicorn"
 end
 

--- a/lib/generators/templates/capistrano/Capfile
+++ b/lib/generators/templates/capistrano/Capfile
@@ -31,7 +31,7 @@ install_plugin Capistrano::SCM::Git
 #   https://github.com/capistrano/rails
 #   https://github.com/capistrano/passenger
 #
-require "capistrano/rvm"
+require 'rvm1/capistrano3'
 # require "capistrano/rbenv"
 # require "capistrano/chruby"
 require "capistrano/bundler"

--- a/lib/generators/templates/capistrano/deploy.rb
+++ b/lib/generators/templates/capistrano/deploy.rb
@@ -15,8 +15,14 @@ set :linked_dirs, fetch(:linked_dirs, [])
 # Default value for keep_releases is 5
 set :keep_releases, 5
 
+before 'rvm1:install:rvm', 'app:update_rvm_key'
+after 'rvm1:install:ruby', 'rvm1:install_bundler'
+
+before 'deploy', 'rvm1:install:rvm'  # install/update RVM
+before 'deploy', 'rvm1:install:ruby'  # install/update Ruby
+
 before 'deploy:check', 'figaro:upload'
-after "deploy:publishing", "deploy:restart"
+after 'deploy:publishing', 'deploy:restart'
 
 # Restart unicorn
 namespace :deploy do
@@ -30,8 +36,24 @@ namespace :figaro do
   task :upload do
     on roles(:all) do
       execute "mkdir -p #{shared_path}/config"
-      
       upload! 'config/application.yml', "#{shared_path}/config/application.yml"
+    end
+  end
+end
+
+namespace :app do
+  task :update_rvm_key do
+    roles(:all) do
+      execute :gpg, "--keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3"
+    end
+  end
+end
+
+namespace :rvm1 do # https://github.com/rvm/rvm1-capistrano3/issues/45
+  desc "Install Bundler"
+  task :install_bundler do
+    on release_roles :all do
+      execute "cd #{release_path} && #{fetch(:rvm1_auto_script_path)}/rvm-auto.sh . gem install bundler"
     end
   end
 end


### PR DESCRIPTION
This change was first made and tested in the Papiamentu project.

- Adds installation of rvm and ruby before deploy