### PR TITLE
Added CancanConcern in order to encapsulate cancan InlineFormsController methods

### DIFF
--- a/lib/app/controllers/concerns/cancan_concern.rb
+++ b/lib/app/controllers/concerns/cancan_concern.rb
@@ -1,0 +1,25 @@
+module CancanConcern
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :cancan_disabled?, :cancan_enabled?
+  end
+
+  class_methods do
+    def cancan_enabled?
+      begin
+        CanCan::Ability && true
+      rescue NameError
+        false
+      end
+    end
+  end
+
+  def cancan_enabled?
+    self.class.cancan_enabled?
+  end
+
+  def cancan_disabled?
+    ! self.class.cancan_enabled?
+  end
+end

--- a/lib/app/controllers/inline_forms_controller.rb
+++ b/lib/app/controllers/inline_forms_controller.rb
@@ -22,25 +22,9 @@
 # @Klass is used in the InlineFormsHelper
 #
 class InlineFormsController < ApplicationController
+  include CancanConcern
+
   before_action :getKlass
-
-  def self.cancan_enabled?
-    begin
-      CanCan::Ability && true
-    rescue NameError
-      false
-    end
-  end
-
-  def cancan_enabled?
-    self.class.cancan_enabled?
-  end
-
-  def cancan_disabled?
-    ! self.class.cancan_enabled?
-  end
-
-  helper_method :cancan_disabled?, :cancan_enabled?
 
   load_and_authorize_resource :except => :revert, :no_params => true if cancan_enabled?
   # :index shows a list of all objects from class @Klass, using will_paginate,


### PR DESCRIPTION
This way the functionalities added by inline_forms are mor flexible and easy to integrate into main app controllers. For example, this way InlineFormsController functionality can added to others main app Controllers - extending from InlineFormsController - as a whole but also just a part of the functionality by including the concern.

This was implemented as a need for Papiamentu app. In the Papiamentu app the FrontendController needs just some functionality - the cancan one - from InlineFormsController but not all the funcionality. 