### PR TITLE
Divided the top-bar-and-flash partial in two separated partials

### DIFF
--- a/lib/app/views/devise/sessions/_flash.html.erb
+++ b/lib/app/views/devise/sessions/_flash.html.erb
@@ -1,0 +1,7 @@
+<% if !flash.empty? %>
+  <div id='inline_forms_devise_flash_div' class='row'>
+    <% flash.each do |name, msg| %>
+      <%= content_tag :div, msg, :id => "flash_#{name}", :class => 'devise flash' %>
+    <% end %>
+  </div>
+<% end %>

--- a/lib/app/views/devise/sessions/_top-bar-and-flash.html.erb
+++ b/lib/app/views/devise/sessions/_top-bar-and-flash.html.erb
@@ -1,19 +1,2 @@
-<div class='contain-to-grid'>
-  <nav id='inline_forms_devise_top_nav_bar' class='top-bar' data-topbar>
-    <ul class='title-area'>
-      <li class='name'>
-        <h1><a href='/'><%= t('inline_forms.devise.title_for_devise') %> <%= InlineForms::VERSION %></a></h1>
-      </li>
-      <li class='toggle-topbar menu-icon'>
-        <a href='#'><span></span></a>
-      </li>
-    </ul>
-  </nav>
-</div>
-
-<div id='inline_forms_devise_flash_div' class='row'>
-  <% flash = @flash %>
-  <% flash.each do |name, msg| %>
-    <%= content_tag :div, msg, :id => "flash_#{name}", :class => 'devise flash' %>
-  <% end unless flash.blank? %>
-</div>
+<%= render 'top-bar' %>
+<%= render 'flash' %>

--- a/lib/app/views/devise/sessions/_top-bar.html.erb
+++ b/lib/app/views/devise/sessions/_top-bar.html.erb
@@ -1,0 +1,12 @@
+<div class='contain-to-grid'>
+  <nav id='inline_forms_devise_top_nav_bar' class='top-bar' data-topbar>
+    <ul class='title-area'>
+      <li class='name'>
+        <h1><a href='/'><%= t('inline_forms.devise.title_for_devise') %> <%= InlineForms::VERSION %></a></h1>
+      </li>
+      <li class='toggle-topbar menu-icon'>
+        <a href='#'><span></span></a>
+      </li>
+    </ul>
+  </nav>
+</div>


### PR DESCRIPTION
This change is needed because the Rails apps using inline_forms most probably will use the flash partial but they will not use the same topbar as happends in the Papiamentu.info app.