### PR TITLE
Added turbolinks gem into the gem file created during app generation

### DIFF
--- a/bin/inline_forms_installer_core.rb
+++ b/bin/inline_forms_installer_core.rb
@@ -33,6 +33,8 @@ gem 'figaro'
 gem 'unicorn'
 gem 'validation_hints'
 gem 'will_paginate' #, git: 'https://github.com/acesuares/will_paginate.git'
+# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
+gem 'turbolinks', '~> 5'
 
 gem_group :development do
   gem 'bundler'


### PR DESCRIPTION
Rails adds turbolinks as a default gem and since we are not anymore overwritten the application.js file, the main app will be expecting that this gem is installed. 