### PR TITLE
paper_trail with changes

### DIFF
--- a/bin/inline_forms_installer_core.rb
+++ b/bin/inline_forms_installer_core.rb
@@ -292,7 +292,7 @@ say "- Set languages for ckeditor to ['en', 'nl'] in config/initializers/ckedito
 insert_into_file "config/initializers/ckeditor.rb", "  config.assets_languages = ['en', 'nl']\n", :after => "config.assets_languages = ['en', 'uk']\n"
 
 say "- Paper_trail install..."
-generate "paper_trail:install" # TODO One day, we need some management tools so we can actually SEE the versions, restore them etc.
+generate "paper_trail:install --with-changes"
 
 say "- Import migrations from engines"
 run "bundle exec rails railties:install:migrations" # This is needed to add changeset field to the paper_trail versions table

--- a/bin/inline_forms_installer_core.rb
+++ b/bin/inline_forms_installer_core.rb
@@ -294,9 +294,6 @@ insert_into_file "config/initializers/ckeditor.rb", "  config.assets_languages =
 say "- Paper_trail install..."
 generate "paper_trail:install --with-changes"
 
-say "- Import migrations from engines"
-run "bundle exec rails railties:install:migrations" # This is needed to add changeset field to the paper_trail versions table
-
 # Create Translations
 say "- Generate models and tables and views for translations..." # TODO Translations need to be done in inline_forms, and then generate a yml file, perhaps
 generate "inline_forms", "InlineFormsLocale name:string inline_forms_translations:belongs_to _enabled:yes _presentation:\#{name}"

--- a/db/migrate/20180116154757_add_object_changes_to_versions.rb
+++ b/db/migrate/20180116154757_add_object_changes_to_versions.rb
@@ -1,5 +1,0 @@
-class AddObjectChangesToVersions < ActiveRecord::Migration[5.0]
-  def change
-    add_column :versions, :object_changes, :text
-  end
-end

--- a/lib/inline_forms.rb
+++ b/lib/inline_forms.rb
@@ -138,14 +138,6 @@ module InlineForms
   # Declare as a Rails::Engine, see http://www.ruby-forum.com/topic/211017#927932
   class Engine < Rails::Engine
 
-    initializer :append_migrations do |app|
-      unless app.root.to_s.match(root.to_s)
-        config.paths["db/migrate"].expanded.each do |path|
-          app.config.paths["db/migrate"] << path
-        end
-      end
-    end
-
     initializer "inline_forms.assets.precompile" do |app|
       app.config.assets.precompile += %w( inline_forms/inline_forms.scss
         inline_forms/devise.css


### PR DESCRIPTION
In order to have access to which files (attributes!) are changed from version to version we install paper_trail `--with-changes`  instead of manually adding that a migration in the engine.

Apps created with inline_forms < this version need to manually add the migration. 