### PR TITLE
Close versions link does not needs its own route

### DIFF
--- a/app/controllers/concerns/versions_concern.rb
+++ b/app/controllers/concerns/versions_concern.rb
@@ -8,18 +8,16 @@ module VersionsConcern
   def list_versions
     @update_span = params[:update]
     @object = referenced_object
-    respond_to do |format|
-      format.html { } unless @Klass.not_accessible_through_html?
-      format.js { render :versions_list }
-    end
-  end
-
-  def close_versions_list
-    @update_span = params[:update]
-    @object = referenced_object
-    respond_to do |format|
-      format.html { } unless @Klass.not_accessible_through_html?
-      format.js { render :versions }
+    close = params[:close] || false
+    if close
+      respond_to do |format|
+        format.js { render :versions }
+      end
+    else
+      respond_to do |format|
+        format.html { } unless @Klass.not_accessible_through_html?
+        format.js { render :versions_list }
+      end
     end
   end
 end

--- a/app/helpers/inline_forms_helper.rb
+++ b/app/helpers/inline_forms_helper.rb
@@ -107,9 +107,10 @@ module InlineFormsHelper
   # close versions list link
   def close_versions_list_link(object, update_span, html_class = 'button close_button' )
     link_to "<i class='fi-x'></i>".html_safe,
-      send('close_versions_list_' + @object.class.to_s.underscore + "_path",
+      send('list_versions_' + @object.class.to_s.underscore + "_path",
           object,
-          :update => update_span
+          :update => update_span,
+          :close => true
       ),
       :remote => true,
       :class => html_class,

--- a/bin/inline_forms_installer_core.rb
+++ b/bin/inline_forms_installer_core.rb
@@ -95,7 +95,6 @@ devise_for :users, :path_prefix => 'auth'
   resources :users do
     post 'revert', :on => :member
     get 'list_versions', :on => :member
-    get 'close_versions_list', :on => :member
 end
 ROUTE
 

--- a/lib/generators/inline_forms_generator.rb
+++ b/lib/generators/inline_forms_generator.rb
@@ -173,7 +173,6 @@ module InlineForms
           resources :#{resource_name} do
             post 'revert', :on => :member
             get 'list_versions', :on => :member
-            get 'close_versions_list', :on => :member
           end
         ROUTE
       end


### PR DESCRIPTION
The close versions link does a get request to the server but it can rely on the same list_versions route just using a flag variable `close` in order know if the user is asking to list or close the version list.

This kind of action, close a div, maybe even don't should make a `get request` to the server, but let think about this when refactoring all the ajax stuff. 