### PR TITLE
Showing the versions list only to users with the ability list_versions

### DIFF
--- a/app/helpers/inline_forms_helper.rb
+++ b/app/helpers/inline_forms_helper.rb
@@ -99,7 +99,7 @@ module InlineFormsHelper
                    :class => html_class,
                    :title => t('inline_forms.view.list_versions')
           )
-    if current_user.role? :superadmin
+    if can? :list_versions, object.class.name.pluralize.underscore.to_sym
       raw out
     end
   end

--- a/app/views/inline_forms/_show.html.erb
+++ b/app/views/inline_forms/_show.html.erb
@@ -115,7 +115,7 @@
         <% end %>
       <% end %>
     <% end %>
-    <% if current_user.role? :superadmin %>
+    <% if can? :list_versions, @object.class.name.pluralize.underscore.to_sym  %>
       <% css_class_id = "#{@object.class.name.underscore}_#{@object.id}_versions" -%>
       <div id="<%= css_class_id -%>">
         <%= render 'versions' %>


### PR DESCRIPTION
Once this is merge, in the main app in the ability.rb file we could decide with users are able to list versions.

`can :list_versions,          :words`

A manage_versions ability is the combination of list_versions and revert, in some situation with could make something like this

`alias_action(:list_versions, :revert, to: :manage_versions)`