### PR TITLE
Audio field

### DIFF
--- a/app/helpers/form_elements/audio_field.rb
+++ b/app/helpers/form_elements/audio_field.rb
@@ -12,7 +12,11 @@ def audio_field_show(object, attribute)
     end
   end
   link_to_edit = link_to_inline_edit object, attribute, msg
-  "#{audio_html} #{link_to_edit}".html_safe
+  if cancan_disabled? || ( can? :update, object, attribute )
+    "#{audio_html} #{link_to_edit}".html_safe
+  else
+    audio_html.html_safe
+  end
 end
 
 def audio_field_edit(object, attribute)

--- a/app/helpers/form_elements/audio_field.rb
+++ b/app/helpers/form_elements/audio_field.rb
@@ -1,0 +1,24 @@
+# -*- encoding : utf-8 -*-
+InlineForms::SPECIAL_COLUMN_TYPES[:audio_field]=:string
+
+def audio_field_show(object, attribute)
+  o = object.send(attribute)
+  msg = "<i class='fi-pencil' title='Edit #{attribute.to_s}'></i>".html_safe
+  if o.send(:present?)
+    if o.respond_to? :palm
+      audio_html = audio_tag(o.send(:palm).send(:url), autoplay: false, controls: true)
+    else
+      audio_html = audio_tag(o.send(:url), autoplay: false, controls: true)
+    end
+  end
+  link_to_edit = link_to_inline_edit object, attribute, msg
+  "#{audio_html} #{link_to_edit}".html_safe
+end
+
+def audio_field_edit(object, attribute)
+  file_field_tag attribute, class: 'input_text_field'
+end
+
+def audio_field_update(object, attribute)
+  object.send(attribute.to_s + '=', params[attribute.to_sym])
+end

--- a/lib/generators/inline_forms_generator.rb
+++ b/lib/generators/inline_forms_generator.rb
@@ -111,7 +111,8 @@ module InlineForms
             ## :drop_down, :references and :belongs_to all end up with the column_type :belongs_to
             @belongs_to << '  belongs_to :'         + attribute.name + "\n"
           end
-          if attribute.type  == :image_field # upload images via carrierwave
+          # upload images or audio files via carrierwave
+          case attribute.type when :image_field, :audio_field then
             @carrierwave_mounters << '  mount_uploader :' + attribute.name + ', ' + "#{attribute.name}_uploader".camelcase + "\n"
           end
           if attribute.type         == :has_many ||


### PR DESCRIPTION
This PR adds a new field type, the audio_field, so you can do:

```
rails g inline_forms Dog name:string caption:string audio:audio_field description:text _enabled:yes _presentation:'#{name}'
rails generate uploader Audio

```
and this give you...

![audio_field](https://user-images.githubusercontent.com/413133/36030649-7a4242ae-0d7e-11e8-81de-72d475e5b4e4.gif)



